### PR TITLE
Add basic CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,22 @@
+import argparse
+import json
+
+import PTN
+
+parser = argparse.ArgumentParser(
+    description="Extract media information from torrent-like filename."
+)
+parser.add_argument("torrent", type=str, help="a torrent-like filename")
+parser.add_argument(
+    "--raw",
+    dest="standardise",
+    action="store_const",
+    const=False,
+    default=True,
+    help="whether to standardise the output",
+)
+args = parser.parse_args()
+
+parsed = PTN.parse(args.torrent, standardise=args.standardise)
+
+print(json.dumps(parsed, indent=2))

--- a/cli.py
+++ b/cli.py
@@ -13,7 +13,7 @@ parser.add_argument(
     action="store_const",
     const=False,
     default=True,
-    help="whether to standardise the output",
+    help="don't standardise the output",
 )
 args = parser.parse_args()
 


### PR DESCRIPTION
This is a very basic argparse CLI. It requires a torrent-like filename and the optional `--raw` argument controls whether the output is standardised. The output is indented JSON.

This is the help output:

```
$ python cli.py --help
usage: cli.py [-h] [--raw] torrent

Extract media information from torrent-like filename.

positional arguments:
  torrent     a torrent-like filename

optional arguments:
  -h, --help  show this help message and exit
  --raw       whether to standardise the output
```

This is an example the output:

```
$ python cli.py "Some.Show.S01.2160p.WEB-DL.DDP5.1.Atmos.HEVC-GROUP.mkv"
{
  "season": 1,
  "resolution": "2160p",
  "quality": "WEB-DL",
  "codec": "H.265",
  "audio": "Dolby Atmos",
  "filetype": "MKV",
  "title": "Some Show",
  "encoder": "GROUP"
}
```

```
$ python cli.py --raw "Some.Show.S01.2160p.WEB-DL.DDP5.1.Atmos.HEVC-GROUP.mkv"
{
  "season": 1,
  "resolution": "2160p",
  "quality": "WEB-DL",
  "codec": "HEVC",
  "audio": "Atmos",
  "filetype": "mkv",
  "title": "Some Show",
  "encoder": "GROUP"
}
```

Feel free to close this PR and use the code as a basis for a less basic CLI like the one described in https://github.com/platelminto/parse-torrent-title/issues/27.