### PR TITLE
Add edition to patterns

### DIFF
--- a/PTN/patterns.py
+++ b/PTN/patterns.py
@@ -83,6 +83,7 @@ patterns_ordered = [
     "remux",
     "internationalCut",
     "genre",
+    "edition",
 ]
 
 
@@ -350,6 +351,20 @@ patterns["language"] = [
     + patterns["subtitles"][-2]
     + ")",
 ]
+
+patterns["edition"] = [
+    (r"\b\d{{2,3}}(th)?{d}Anniversary{d}(Edition|Ed)?\b".format(d=delimiters), "Anniversary Edition"),
+    (r"\bUltimate{d}Edition\b".format(d=delimiters), "Ultimate Edition"),
+    (r"\bExtended{d}Director\"?s\b".format(d=delimiters), "Directors Cut"), # Needs to be before "Extended"
+    (r"\bExtended\b", "Extended Edition"),
+    (r"\bDirector\"?s{d}Cut\b".format(d=delimiters), "Directors Cut"),
+    (r"\bCollector\"?s\b", "Collectors Edition"),
+    (r"\bTheatrical\b", "Theatrical"),
+    (r"\bUncut\b", "Uncut"),
+    (r"\bIMAX\b", "IMAX"),
+    (r"\bDiamond\b", "Diamond Edition"),  # Might be too loose?
+]
+
 patterns["sbs"] = [("Half-SBS", "Half SBS"), ("SBS", None, "upper")]
 patterns["unrated"] = "UNRATED"
 patterns["size"] = (
@@ -401,4 +416,5 @@ types = {
     "untouched": "boolean",
     "remux": "boolean",
     "internationalCut": "boolean",
+    "edition": "string",
 }

--- a/tests/files/input.json
+++ b/tests/files/input.json
@@ -402,5 +402,7 @@
   "The Good German (2006).VOSTFR.720p.WEBDL.h264.aac.mkv",
   "www.Torrenting.com   -    Anatomy Of A Fall (2023)",
   "Eu.gosto.do.Homem-Aranha.e.dai.1080p.AAC2.0.H264.mkv",
-  "www.1TamilBlasters.lat - Thuritham (2023) [Tamil - 2K QHD AVC UNTOUCHED - x264 - AAC - 3.4GB - ESub].mkv"
+  "www.1TamilBlasters.lat - Thuritham (2023) [Tamil - 2K QHD AVC UNTOUCHED - x264 - AAC - 3.4GB - ESub].mkv",
+  "Jurassic Park 1993 20th.Anniversary.Edition 1080p",
+  "The.Lord.of.the.Rings.The.Motion.Picture.Trilogy.Extended.Editions.2001-2003.1080p.BluRay.x264.DTS-WiKi"
 ]

--- a/tests/files/output_raw.json
+++ b/tests/files/output_raw.json
@@ -3682,5 +3682,24 @@
     "title": "Thuritham",
     "untouched": true,
     "year": 2023
+  },
+  {
+    "resolution": "1080p",
+    "year": 1993,
+    "edition": "Anniversary Edition",
+    "title": "Jurassic Park"
+  },
+  {
+    "resolution": "2160p",
+    "quality": "Blu-ray",
+    "year": 2001,
+    "codec": "H.265",
+    "audio": "Dolby TrueHD 7.1",
+    "extended": true,
+    "bitDepth": 10,
+    "hdr": true,
+    "edition": "Extended Edition",
+    "title": "The Lord of the Rings The Fellowship of the Ring",
+    "encoder": "BOREDOR"
   }
 ]


### PR DESCRIPTION
This could possibly use some slight tweaking, but it works well. Let me know if anything needs changed! 

Added 2 tests as well.

Ex:

"The.Lord.of.the.Rings.The.Fellowship.of.the.Ring.2001.EXTENDED.2160p.UHD.BluRay.x265.10bit.HDR.TrueHD.7.1.Atmos-BOREDOR"

```json
{
  "resolution": "2160p",
  "quality": "Blu-ray",
  "year": 2001,
  "codec": "H.265",
  "audio": "Dolby TrueHD 7.1",
  "extended": true,
  "bitDepth": 10,
  "hdr": true,
  "edition": "Extended Edition",
  "title": "The Lord of the Rings The Fellowship of the Ring",
  "encoder": "BOREDOR"
}
```